### PR TITLE
[2.0.r1] Kbuild: Always define QCOM_KGSL

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -8,10 +8,7 @@ ifeq ($(KGSL_PATH),)
 KGSL_PATH=$(src)
 endif
 
-# If we're not in an Android tree, select KGSL config
-ifeq ($(ANDROID_BUILD_TOP),)
 CONFIG_QCOM_KGSL = y
-endif
 
 ifeq ($(CONFIG_ARCH_WAIPIO), y)
 	include $(KGSL_PATH)/config/gki_waipiodisp.conf


### PR DESCRIPTION
The kernel with this driver can be compiled in the Android
tree and with ANDROID_BUILD_TOP defined, which will prevent
the driver from being built. Make the flag independent of
it and always define it.
